### PR TITLE
feat(exists): new API using type names instead of query fields

### DIFF
--- a/src/Graphcool.ts
+++ b/src/Graphcool.ts
@@ -107,7 +107,7 @@ class ExistsHandler implements ProxyHandler<Graphcool> {
       while (isWrappingType(type)) {
         type = type.ofType
         // One of those wrappings need to be a GraphQLList for this field to qualify
-        foundList = isListType(type)
+        foundList = foundList || isListType(type)
       }
       if (foundList && (<GraphQLNamedType>type).name == typeName) {
         return fieldDef.name

--- a/src/graphql.d.ts
+++ b/src/graphql.d.ts
@@ -1,0 +1,9 @@
+// Missing declarations in @types/graphql
+import { GraphQLList, GraphQLNonNull, GraphQLType } from "graphql";
+
+declare module 'graphql' {
+    export type GraphQLWrappingType = GraphQLList<any> | GraphQLNonNull<any>;
+
+    export function isWrappingType(type: GraphQLType): type is GraphQLWrappingType
+    export function isListType(type: GraphQLType): type is GraphQLList<any>
+}


### PR DESCRIPTION
BREAKING CHANGE: this feature breaks current exists calls.

Old: `context.db.exists.posts(...)`
New: `context.db.exists.Post(...)`